### PR TITLE
Add Buzzer M214 code.

### DIFF
--- a/src/replicatorg/app/gcode/GCodeEnumeration.java
+++ b/src/replicatorg/app/gcode/GCodeEnumeration.java
@@ -78,6 +78,7 @@ public enum GCodeEnumeration {
 	M141("M", 141, "Set Chamber Temperature (Ignored)"),
 	M142("M", 142, "Set Chamber Holding Pressure (Ignored)"),
 	M200("M", 200, "Reset driver"),
+	M214("M", 214, "Beep. Defaults 0 for I, J, and K"),
 	M300("M", 300, "Set Servo 1 Position"),
 	M301("M", 301, "Set Servo 2 Position"),
 	M310("M", 310, "Start data capture"),

--- a/src/replicatorg/app/gcode/GCodeParser.java
+++ b/src/replicatorg/app/gcode/GCodeParser.java
@@ -566,10 +566,19 @@ public class GCodeParser {
 		case M141: // skeinforge chamber plugin chamber temperature code
 		case M142: // skeinforge chamber plugin holding pressure code
 			break;
-		
 		// initialize to default state.
 		case M200:
 			commands.add(new replicatorg.drivers.commands.Initialize());
+			break;
+		// play beep
+		case M214:
+			int num = 0;
+			int dur = 0;
+			int rep = 0;
+			if (gcode.hasCode('I')) num = (int) gcode.getCodeValue('I');
+			if (gcode.hasCode('J')) dur = (int) gcode.getCodeValue('J');
+			if (gcode.hasCode('K')) rep = (int) gcode.getCodeValue('K');
+			commands.add(new replicatorg.drivers.commands.SendBeep(num, dur, rep));
 			break;
 		// set servo 1 position
 		case M300:


### PR DESCRIPTION
Jetty V1.0 buzzer M code from thing 16170.
I did a fresh implementation using the new (renamed?) sendBeep function.
The required underlying changes for M213 are not present in the sailfish firmware, or I'd have added it as well.

Seems to work with everything I can throw at it.

Walt
