### PR TITLE
Fix for G2 and G3 arc interpolation code

### DIFF
--- a/src/replicatorg/app/gcode/GCodeParser.java
+++ b/src/replicatorg/app/gcode/GCodeParser.java
@@ -145,6 +145,7 @@ public class GCodeParser {
 			else
 				step = steps - s;
 
+			newPoint = new Point5d(current);
 			// calculate our waypoint.
 			newPoint.setX(center.x() + radius * Math.cos(angleA + angle * ((double) step / steps)));
 			newPoint.setY(center.y() + radius * Math.sin(angleA + angle * ((double) step / steps)));


### PR DESCRIPTION
Arc interpolation was using a single reference to the point, which was
being changed on every step generating a 0 delta, which means the arc
was effectively generating a single line for arcs

this fixes that reference issue

Also, the previous time i attempted to fix this issue it was pushed back with the fact it doesn't support 5D, the problem isn't anything to do with 5D and will affect 2D or 3D generation as well, effectively collapsing the Arc into a straight line